### PR TITLE
MOBCore 3.2

### DIFF
--- a/MOBCore.podspec
+++ b/MOBCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MOBCore'
-  s.version          = '3.1.2'
+  s.version          = '3.2'
   s.summary          = 'A core set of functions and extensions to power a slew of applications'
   s.homepage         = 'https://github.com/Moballo-LLC/MOBCore'
   s.license          = 'MIT'

--- a/MOBCore.xcodeproj/project.pbxproj
+++ b/MOBCore.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 3120;
+				CURRENT_PROJECT_VERSION = 3200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -461,7 +461,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.1.2;
+				MARKETING_VERSION = 3.2;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-iquote",
@@ -485,7 +485,7 @@
 					"-fembed-bitcode",
 				);
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.moballo.MOBCore;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.moballo.MOBCore-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -505,7 +505,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 3120;
+				CURRENT_PROJECT_VERSION = 3200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -525,7 +525,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.1.2;
+				MARKETING_VERSION = 3.2;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-iquote",
@@ -549,7 +549,7 @@
 					"-fembed-bitcode",
 				);
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.moballo.MOBCore;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.moballo.MOBCore-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -569,7 +569,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 3120;
+				CURRENT_PROJECT_VERSION = 3200;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
@@ -580,8 +580,8 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.1.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.moballo.MOBCore;
+				MARKETING_VERSION = 3.2;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.moballo.MOBCore-watchOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
@@ -603,7 +603,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 3120;
+				CURRENT_PROJECT_VERSION = 3200;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -613,8 +613,8 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.1.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.moballo.MOBCore;
+				MARKETING_VERSION = 3.2;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.moballo.MOBCore-watchOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;

--- a/Sources-iOS-only/MOBTableViewController.swift
+++ b/Sources-iOS-only/MOBTableViewController.swift
@@ -13,9 +13,9 @@ import UIKit
     override open func viewDidLoad() {
         super.viewDidLoad()
         self.tableView.keyboardDismissMode = .interactive
-//        self.edgesForExtendedLayout = UIRectEdge()
-        self.definesPresentationContext = true
+        self.edgesForExtendedLayout = UIRectEdge()
         self.extendedLayoutIncludesOpaqueBars = false
+        self.definesPresentationContext = true
         self.automaticallyAdjustsScrollViewInsets = false
         if #available(iOS 11.0, *) {
             self.navigationItem.hidesSearchBarWhenScrolling = true
@@ -105,7 +105,6 @@ open class MOBTableViewControllerWithSearch: MOBTableViewController, UISearchCon
             self.navigationItem.searchController = self.searchController
         } else {
             self.tableView.tableHeaderView = self.searchBar
-            //self.navigationItem.titleView = searchController.searchBar
         }
         self.privateSearchEnabled = true
     }
@@ -122,15 +121,17 @@ open class MOBTableViewControllerWithSearch: MOBTableViewController, UISearchCon
         self.searchController.searchResultsUpdater = self
         self.searchController.delegate = self
         self.searchController.dimsBackgroundDuringPresentation = false
-        self.searchController.hidesNavigationBarDuringPresentation = true
+        if #available(iOS 11.0, *) {
+            self.searchController.hidesNavigationBarDuringPresentation = true
+        } else {
+            self.searchController.hidesNavigationBarDuringPresentation = false
+        }
         if #available(iOS 9.1, *) {
             self.searchController.obscuresBackgroundDuringPresentation = false
         }
         self.searchController.definesPresentationContext = false
         if #available(iOS 13.0, *) {
             self.searchController.automaticallyShowsCancelButton = true
-        } else {
-            // Fallback on earlier versions
         }
     }
     public func searchBarIsEmpty() -> Bool {


### PR DESCRIPTION
- Fixed MOBTableView edges for extended layout
- Fixed MOBTableViewSearch layout on older devices
- Made iOS and watchOS builds have different bundle identifiers